### PR TITLE
Support modules with dotted names

### DIFF
--- a/lib/reporters/templates/cobertura.jade
+++ b/lib/reporters/templates/cobertura.jade
@@ -8,7 +8,7 @@ coverage(branch-rate='0', line-rate='#{(cov.coverage / 100) || 0}', timestamp='#
 		package(branch-rate='0', complexity='0.0', line-rate='#{(cov.coverage / 100) || 0}', name='.')
 			classes
 				for file in cov.files
-					class(branch-rate='0', complexity='0.0', filename='#{file.filename}', line-rate='#{(file.coverage / 100) || 0}', name='#{file.filename.split(".")[0]}')
+					class(branch-rate='0', complexity='0.0', filename='#{file.filename}', line-rate='#{(file.coverage / 100) || 0}', name='#{file.filename.split(".").slice(0, -1).join(".")}')
 						methods
 						lines
 							for line, number in file.source


### PR DESCRIPTION
Instead of taking everything before the first dot as the source name, take everything before the last dot.
