### PR TITLE
Update mocha version and fix deprecated doctype info in Jade templates

### DIFF
--- a/lib/reporters/templates/cobertura.jade
+++ b/lib/reporters/templates/cobertura.jade
@@ -1,5 +1,5 @@
-!!! xml
-!!! cobertura
+doctype xml
+doctype cobertura
 coverage(branch-rate='0', line-rate='#{(cov.coverage / 100) || 0}', timestamp='#{+new Date()}', version='3.5.1')
 	sources
 		- var src = "<source>" + cov.src + "</source>"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	  "jade": "1.x.x"
 	},
 	"peerDependencies": {
-	  "mocha": "1.x.x"
+	  "mocha": "2.x.x"
 	},
 	"main": "./index",
 	"bin": {


### PR DESCRIPTION
@sjonnet19 fixes some issues I was running into with newer versions of mocha.
